### PR TITLE
feat(firstaid): Implement precise 3D hitbox detection

### DIFF
--- a/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/EntityKineticBulletHitCaptureMixin.java
+++ b/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/EntityKineticBulletHitCaptureMixin.java
@@ -1,0 +1,28 @@
+package me.muksc.tacztweaks.mixin.compat.firstaid;
+
+import com.tacz.guns.entity.EntityKineticBullet;
+import com.tacz.guns.util.TacHitResult;
+import me.muksc.tacztweaks.mixininterface.features.EntityKineticBulletExtension;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Captures the exact hit location when a TacZ bullet hits an entity.
+ * This data is used by FirstAid integration for precise bodypart targeting.
+ */
+@Mixin(value = EntityKineticBullet.class, remap = false)
+public class EntityKineticBulletHitCaptureMixin {
+
+    @Inject(
+        method = "onHitEntity",
+        at = @At("HEAD")
+    )
+    private void tacztweaks$captureHitLocation(TacHitResult result, Vec3 startVec, Vec3 endVec, CallbackInfo ci) {
+        // Store the exact hit location in the bullet for FirstAid to use
+        Vec3 hitLocation = result.getLocation();
+        ((EntityKineticBulletExtension) this).tacztweaks$setLastHitLocation(hitLocation);
+    }
+}

--- a/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/FirstAidEventHandlerMixin.java
+++ b/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/FirstAidEventHandlerMixin.java
@@ -1,0 +1,100 @@
+package me.muksc.tacztweaks.mixin.compat.firstaid;
+
+import com.tacz.guns.entity.EntityKineticBullet;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import ichttt.mods.firstaid.api.distribution.IDamageDistributionAlgorithm;
+import ichttt.mods.firstaid.common.EventHandler;
+import me.muksc.tacztweaks.compat.firstaid.TacZDamageDistribution;
+import me.muksc.tacztweaks.config.Config;
+import me.muksc.tacztweaks.mixininterface.features.EntityKineticBulletExtension;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Intercepts FirstAid's damage handling to provide precise bodypart targeting for TacZ weapons.
+ * This replaces FirstAid's default random/height-based distribution with our 3D hit detection.
+ */
+@Mixin(value = EventHandler.class, remap = false)
+public class FirstAidEventHandlerMixin {
+
+    private static final ThreadLocal<IDamageDistributionAlgorithm> tacztweaks$customDistribution = new ThreadLocal<>();
+
+    /**
+     * Intercepts damage events to detect TacZ bullets.
+     * Sets up custom distribution algorithms before FirstAid processes the damage.
+     */
+    @Inject(
+        method = "onLivingHurt",
+        at = @At(
+            value = "INVOKE",
+            target = "Lichttt/mods/firstaid/common/util/CommonUtils;getDamageModel(Lnet/minecraft/world/entity/player/Player;)Lichttt/mods/firstaid/api/damagesystem/AbstractPlayerDamageModel;",
+            shift = At.Shift.AFTER
+        )
+    )
+    private static void tacztweaks$detectTacZDamage(LivingHurtEvent event, CallbackInfo ci) {
+        if (!Config.Compat.INSTANCE.firstAidCompat()) return;
+        if (!(event.getEntity() instanceof Player)) return;
+
+        DamageSource source = event.getSource();
+        Entity directEntity = source.getDirectEntity();
+
+        // Check if damage is from a TacZ bullet
+        if (directEntity instanceof EntityKineticBullet) {
+            Vec3 hitLocation = ((EntityKineticBulletExtension) directEntity).tacztweaks$getLastHitLocation();
+
+            if (hitLocation != null) {
+                // Store custom distribution for this bullet
+                tacztweaks$customDistribution.set(new TacZDamageDistribution(hitLocation));
+                return;
+            }
+        }
+
+        // Clear any previous custom distribution
+        tacztweaks$customDistribution.remove();
+    }
+
+    /**
+     * Redirects the handleDamageTaken call to use our custom distribution if available.
+     */
+    @Redirect(
+        method = "onLivingHurt",
+        at = @At(
+            value = "INVOKE",
+            target = "Lichttt/mods/firstaid/common/damagesystem/distribution/DamageDistribution;handleDamageTaken(Lichttt/mods/firstaid/api/distribution/IDamageDistributionAlgorithm;Lichttt/mods/firstaid/api/damagesystem/AbstractPlayerDamageModel;FLnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/damagesource/DamageSource;ZZ)F"
+        )
+    )
+    private static float tacztweaks$replaceDistribution(
+            IDamageDistributionAlgorithm original,
+            AbstractPlayerDamageModel damageModel,
+            float damage,
+            Player player,
+            DamageSource source,
+            boolean addStat,
+            boolean redistributeIfLeft
+    ) {
+        try {
+            IDamageDistributionAlgorithm custom = tacztweaks$customDistribution.get();
+            if (custom != null) {
+                // Call handleDamageTaken with our custom distribution
+                return ichttt.mods.firstaid.common.damagesystem.distribution.DamageDistribution.handleDamageTaken(
+                    custom, damageModel, damage, player, source, addStat, redistributeIfLeft
+                );
+            }
+
+            // Use the original distribution
+            return ichttt.mods.firstaid.common.damagesystem.distribution.DamageDistribution.handleDamageTaken(
+                original, damageModel, damage, player, source, addStat, redistributeIfLeft
+            );
+        } finally {
+            tacztweaks$customDistribution.remove();
+        }
+    }
+}

--- a/src/main/java/me/muksc/tacztweaks/mixin/features/EntityKineticBulletMixin.java
+++ b/src/main/java/me/muksc/tacztweaks/mixin/features/EntityKineticBulletMixin.java
@@ -100,6 +100,19 @@ public abstract class EntityKineticBulletMixin implements EntityKineticBulletExt
         tacztweaks$pelletIndex = index;
     }
 
+    @Unique
+    private Vec3 tacztweaks$lastHitLocation = null;
+
+    @Override
+    public Vec3 tacztweaks$getLastHitLocation() {
+        return tacztweaks$lastHitLocation;
+    }
+
+    @Override
+    public void tacztweaks$setLastHitLocation(Vec3 location) {
+        tacztweaks$lastHitLocation = location;
+    }
+
     @Override
     public void tacztweaks$addDamageModifier(float flat, float multiplier) {
         tacztweaks$damageModifiers.add(new DamageModifier(flat, multiplier));

--- a/src/main/java/me/muksc/tacztweaks/mixininterface/features/EntityKineticBulletExtension.java
+++ b/src/main/java/me/muksc/tacztweaks/mixininterface/features/EntityKineticBulletExtension.java
@@ -35,4 +35,8 @@ public interface EntityKineticBulletExtension {
 
     void tacztweaks$setPelletIndex(int index);
 
+    Vec3 tacztweaks$getLastHitLocation();
+
+    void tacztweaks$setLastHitLocation(Vec3 location);
+
 }

--- a/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/BodypartHitbox.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/BodypartHitbox.kt
@@ -1,0 +1,106 @@
+package me.muksc.tacztweaks.compat.firstaid
+
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.phys.AABB
+import net.minecraft.world.phys.Vec3
+
+/**
+ * Defines 3D hitboxes for player bodyparts in local coordinate space.
+ * All coordinates are relative to the player's center position with rotation applied.
+ */
+object BodypartHitbox {
+
+    enum class BodypartSlot(val part: EnumPlayerPart, val armorSlot: EquipmentSlot) {
+        HEAD(EnumPlayerPart.HEAD, EquipmentSlot.HEAD),
+        BODY(EnumPlayerPart.BODY, EquipmentSlot.CHEST),
+        LEFT_ARM(EnumPlayerPart.LEFT_ARM, EquipmentSlot.CHEST),
+        RIGHT_ARM(EnumPlayerPart.RIGHT_ARM, EquipmentSlot.CHEST),
+        LEFT_LEG(EnumPlayerPart.LEFT_LEG, EquipmentSlot.LEGS),
+        RIGHT_LEG(EnumPlayerPart.RIGHT_LEG, EquipmentSlot.LEGS),
+        LEFT_FOOT(EnumPlayerPart.LEFT_FOOT, EquipmentSlot.FEET),
+        RIGHT_FOOT(EnumPlayerPart.RIGHT_FOOT, EquipmentSlot.FEET);
+
+        companion object {
+            fun fromPart(part: EnumPlayerPart): BodypartSlot? = entries.find { it.part == part }
+        }
+    }
+
+    // Hitbox definitions in local coordinate space (player-relative)
+    private val HITBOXES: Map<BodypartSlot, AABB> = mapOf(
+        // Head: -0.2 to 0.2 (X), 1.5 to 1.8 (Y), -0.2 to 0.2 (Z)
+        BodypartSlot.HEAD to AABB(-0.2, 1.5, -0.2, 0.2, 1.8, 0.2),
+        // Body (Torso): -0.2 to 0.2 (X), 0.7 to 1.5 (Y), -0.15 to 0.15 (Z)
+        BodypartSlot.BODY to AABB(-0.2, 0.7, -0.15, 0.2, 1.5, 0.15),
+        // MIRRORED: Left Arm now on positive X (player's actual left from their perspective)
+        BodypartSlot.LEFT_ARM to AABB(0.2, 0.7, -0.15, 0.4, 1.5, 0.15),
+        // MIRRORED: Right Arm now on negative X (player's actual right from their perspective)
+        BodypartSlot.RIGHT_ARM to AABB(-0.4, 0.7, -0.15, -0.2, 1.5, 0.15),
+        // MIRRORED: Left Leg now on positive X
+        BodypartSlot.LEFT_LEG to AABB(0.0, 0.15, -0.15, 0.2, 0.7, 0.15),
+        // MIRRORED: Right Leg now on negative X
+        BodypartSlot.RIGHT_LEG to AABB(-0.2, 0.15, -0.15, 0.0, 0.7, 0.15),
+        // MIRRORED: Feet
+        BodypartSlot.LEFT_FOOT to AABB(0.0, 0.0, -0.2, 0.2, 0.15, 0.2),
+        BodypartSlot.RIGHT_FOOT to AABB(-0.2, 0.0, -0.2, 0.0, 0.15, 0.2)
+    )
+
+    // Priority order for hit detection
+    private val CHECK_ORDER = arrayOf(
+        BodypartSlot.HEAD,
+        BodypartSlot.LEFT_ARM,
+        BodypartSlot.RIGHT_ARM,
+        BodypartSlot.LEFT_LEG,
+        BodypartSlot.RIGHT_LEG,
+        BodypartSlot.LEFT_FOOT,
+        BodypartSlot.RIGHT_FOOT,
+        BodypartSlot.BODY
+    )
+
+    /**
+     * Checks if the given local coordinate point is contained within a bodypart's hitbox.
+     * @param localPoint Point in player-local coordinate space
+     * @return The bodypart that contains this point, or null if no match
+     */
+    fun getHitPart(localPoint: Vec3): EnumPlayerPart? {
+        for (slot in CHECK_ORDER) {
+            val box = HITBOXES[slot] ?: continue
+            if (box.contains(localPoint)) {
+                return slot.part
+            }
+        }
+        return null
+    }
+
+    /**
+     * Gets the center point of a bodypart's hitbox in local coordinates.
+     * @param part The bodypart
+     * @return Center point, or Vec3.ZERO if not found
+     */
+    fun getPartCenter(part: EnumPlayerPart): Vec3 {
+        val slot = BodypartSlot.fromPart(part) ?: return Vec3.ZERO
+        val box = HITBOXES[slot] ?: return Vec3.ZERO
+        return box.center
+    }
+
+    /**
+     * Finds the closest bodypart to the given local point.
+     * Used as a fallback when precise hit detection fails.
+     * @param localPoint Point in local coordinate space
+     * @return The closest bodypart
+     */
+    fun getClosestPart(localPoint: Vec3): EnumPlayerPart {
+        var closest = EnumPlayerPart.BODY
+        var minDistance = Double.MAX_VALUE
+
+        for (slot in BodypartSlot.entries) {
+            val center = getPartCenter(slot.part)
+            val distance = center.distanceToSqr(localPoint)
+            if (distance < minDistance) {
+                minDistance = distance
+                closest = slot.part
+            }
+        }
+        return closest
+    }
+}

--- a/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/CoordinateTransform.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/CoordinateTransform.kt
@@ -1,0 +1,98 @@
+package me.muksc.tacztweaks.compat.firstaid
+
+import com.tacz.guns.api.entity.IGunOperator
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart
+import net.minecraft.util.Mth
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.phys.Vec3
+
+/**
+ * Utility for converting world-space hit vectors to player-local coordinate space.
+ * Handles player rotation and posture (standing/crawling).
+ */
+object CoordinateTransform {
+
+    /**
+     * Converts a world-space hit position to player-local coordinates.
+     * @param worldHit The hit position in world coordinates
+     * @param player The player being hit
+     * @return The hit position in local (player-relative) coordinates
+     */
+    fun worldToLocal(worldHit: Vec3, player: Player): Vec3 {
+        // Step 1: Translate to player-relative coordinates
+        val relative = worldHit.subtract(player.position())
+
+        // Step 2: Rotate by inverse player yaw to align with local axes
+        val yaw = -player.yRot * Mth.DEG_TO_RAD
+        val cos = Mth.cos(yaw)
+        val sin = Mth.sin(yaw)
+
+        val localX = relative.x * cos - relative.z * sin
+        val localZ = relative.x * sin + relative.z * cos
+
+        // Step 3: Apply crawl rotation if player is prone
+        return if (isCrawling(player)) {
+            rotateCrawl(Vec3(localX, relative.y, localZ))
+        } else {
+            Vec3(localX, relative.y, localZ)
+        }
+    }
+
+    /**
+     * Checks if the player is in a crawling/prone state.
+     * @param player The player to check
+     * @return True if crawling
+     */
+    private fun isCrawling(player: Player): Boolean {
+        val operator = IGunOperator.fromLivingEntity(player)
+        return operator?.dataHolder?.isCrawling == true
+    }
+
+    /**
+     * Rotates the local coordinates 90 degrees around the X-axis for crawling players.
+     * This transforms "up" (Y) into "forward" (Z) and vice versa.
+     * @param local The local coordinates for a standing player
+     * @return The adjusted local coordinates for a crawling player
+     */
+    private fun rotateCrawl(local: Vec3): Vec3 {
+        // Rotate 90 degrees around X-axis: Y becomes -Z, Z becomes Y
+        return Vec3(local.x, local.z, -local.y)
+    }
+
+    /**
+     * Gets the center position of a bodypart in world coordinates.
+     * @param player The player
+     * @param part The bodypart
+     * @return World position of the bodypart center
+     */
+    fun getPartWorldPosition(player: Player, part: EnumPlayerPart): Vec3 {
+        val localCenter = BodypartHitbox.getPartCenter(part)
+        return localToWorld(localCenter, player)
+    }
+
+    /**
+     * Converts local coordinates back to world space.
+     * @param local Local coordinates
+     * @param player The player
+     * @return World coordinates
+     */
+    fun localToWorld(local: Vec3, player: Player): Vec3 {
+        // Reverse crawl rotation if needed
+        val adjusted = if (isCrawling(player)) {
+            Vec3(local.x, -local.z, local.y)
+        } else {
+            local
+        }
+
+        // Rotate by player yaw
+        val yaw = player.yRot * Mth.DEG_TO_RAD
+        val cos = Mth.cos(yaw)
+        val sin = Mth.sin(yaw)
+
+        val worldX = adjusted.x * cos - adjusted.z * sin
+        val worldZ = adjusted.x * sin + adjusted.z * cos
+
+        // Translate to world position
+        return player.position().add(worldX, adjusted.y, worldZ)
+    }
+}

--- a/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/ExplosionDistributor.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/ExplosionDistributor.kt
@@ -1,0 +1,119 @@
+package me.muksc.tacztweaks.compat.firstaid
+
+import com.mojang.serialization.Codec
+import ichttt.mods.firstaid.FirstAid
+import ichttt.mods.firstaid.FirstAidConfig
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel
+import ichttt.mods.firstaid.api.distribution.IDamageDistributionAlgorithm
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart
+import ichttt.mods.firstaid.common.network.MessageUpdatePart
+import ichttt.mods.firstaid.common.util.ArmorUtils
+import ichttt.mods.firstaid.common.util.CommonUtils
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.damagesource.DamageSource
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.phys.Vec3
+import net.minecraftforge.network.PacketDistributor
+
+/**
+ * Distributes explosion damage based on proximity of bodyparts to the blast center.
+ * Uses distance-based falloff for realistic explosion damage.
+ */
+class ExplosionDistributor(private val explosionCenter: Vec3) : IDamageDistributionAlgorithm {
+
+    companion object {
+        val CODEC: Codec<ExplosionDistributor> = Codec.unit { ExplosionDistributor(Vec3.ZERO) }
+    }
+
+    override fun distributeDamage(
+        totalDamage: Float,
+        player: Player,
+        source: DamageSource,
+        addStat: Boolean
+    ): Float {
+        val damageModel = CommonUtils.getDamageModel(player) ?: return totalDamage
+
+        // Calculate distances from explosion center to all bodypart centers
+        val distances = EnumPlayerPart.entries.associateWith { part ->
+            val partWorldPos = CoordinateTransform.getPartWorldPosition(player, part)
+            partWorldPos.distanceToSqr(explosionCenter)
+        }
+
+        // Sort parts by proximity (closest first)
+        val sortedParts = distances.entries.sortedBy { it.value }
+
+        // Distribute damage with falloff
+        // Closest: 50%, Second: 25%, Third: 15%, Rest: 10% split
+        if (sortedParts.isNotEmpty()) {
+            applyExplosionDamage(damageModel, player, source, sortedParts[0].key, totalDamage * 0.50f, addStat)
+        }
+        if (sortedParts.size >= 2) {
+            applyExplosionDamage(damageModel, player, source, sortedParts[1].key, totalDamage * 0.25f, addStat)
+        }
+        if (sortedParts.size >= 3) {
+            applyExplosionDamage(damageModel, player, source, sortedParts[2].key, totalDamage * 0.15f, addStat)
+        }
+        // Distribute remaining 10% among other parts
+        if (sortedParts.size > 3) {
+            val remainingDamage = totalDamage * 0.10f
+            val perPart = remainingDamage / (sortedParts.size - 3)
+            for (i in 3 until sortedParts.size) {
+                applyExplosionDamage(damageModel, player, source, sortedParts[i].key, perPart, addStat)
+            }
+        }
+
+        // Return 0 because we handled all damage components with our falloff distribution
+        return 0f
+    }
+
+    /**
+     * Applies explosion damage to a specific part with armor absorption and spillover support.
+     */
+    private fun applyExplosionDamage(
+        damageModel: AbstractPlayerDamageModel,
+        player: Player,
+        source: DamageSource,
+        partEnum: EnumPlayerPart,
+        damage: Float,
+        addStat: Boolean
+    ) {
+        var currentDamage = damage
+        val armorSlot = getMappedSlot(partEnum)
+
+        // Apply armor absorption
+        currentDamage = ArmorUtils.applyArmor(player, player.getItemBySlot(armorSlot), source, currentDamage, armorSlot)
+        if (currentDamage <= 0F) return
+
+        // Apply enchantment modifiers
+        currentDamage = ArmorUtils.applyEnchantmentModifiers(player, armorSlot, source, currentDamage)
+        if (currentDamage <= 0F) return
+
+        val part = damageModel.getFromEnum(partEnum)
+        val minHealth = if (part.canCauseDeath && FirstAidConfig.SERVER.useFriendlyRandomDistribution.get()) 1.0f else 0f
+
+        val undelivered = part.damage(currentDamage, player, addStat, minHealth)
+
+        // Sync to client
+        if (player is ServerPlayer) {
+            FirstAid.NETWORKING.send(PacketDistributor.PLAYER.with { player }, MessageUpdatePart(part))
+        }
+
+        if (undelivered > 0 && partEnum != EnumPlayerPart.BODY && partEnum != EnumPlayerPart.HEAD) {
+            // Apply spillover to body (1.0 ratio for explosions)
+            SpilloverHandler.applySpillover(player, partEnum, undelivered, true)
+        }
+    }
+
+    /**
+     * Maps a body part to an equipment slot for armor protection calculation.
+     */
+    private fun getMappedSlot(part: EnumPlayerPart): EquipmentSlot = when (part) {
+        EnumPlayerPart.HEAD -> EquipmentSlot.HEAD
+        EnumPlayerPart.BODY, EnumPlayerPart.LEFT_ARM, EnumPlayerPart.RIGHT_ARM -> EquipmentSlot.CHEST
+        EnumPlayerPart.LEFT_LEG, EnumPlayerPart.RIGHT_LEG -> EquipmentSlot.LEGS
+        EnumPlayerPart.LEFT_FOOT, EnumPlayerPart.RIGHT_FOOT -> EquipmentSlot.FEET
+    }
+
+    override fun codec(): Codec<out IDamageDistributionAlgorithm> = CODEC
+}

--- a/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/SpilloverHandler.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/SpilloverHandler.kt
@@ -1,0 +1,109 @@
+package me.muksc.tacztweaks.compat.firstaid
+
+import ichttt.mods.firstaid.FirstAid
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart
+import ichttt.mods.firstaid.common.network.MessageUpdatePart
+import ichttt.mods.firstaid.common.util.CommonUtils
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.entity.player.Player
+import net.minecraftforge.network.PacketDistributor
+
+/**
+ * Handles damage spillover from limbs to torso when limb health is depleted.
+ * Calls FirstAid's bodyPart.damage() directly, which bypasses vanilla i-frames.
+ */
+object SpilloverHandler {
+
+    /**
+     * Applies spillover damage from a limb to the torso.
+     * @param player The player receiving spillover damage
+     * @param sourcePart The bodypart that was originally hit
+     * @param remainingDamage The damage that exceeded the limb's health
+     * @param isExplosion Whether the damage came from an explosion
+     */
+    fun applySpillover(
+        player: Player,
+        sourcePart: EnumPlayerPart,
+        remainingDamage: Float,
+        isExplosion: Boolean
+    ) {
+        // Skip spillover for critical parts (they handle death differently)
+        if (sourcePart == EnumPlayerPart.HEAD || sourcePart == EnumPlayerPart.BODY) {
+            return
+        }
+
+        val damageModel = CommonUtils.getDamageModel(player) ?: return
+
+        // Special handling for feet: damage spills to leg first, then to body
+        if (sourcePart == EnumPlayerPart.LEFT_FOOT || sourcePart == EnumPlayerPart.RIGHT_FOOT) {
+            handleFootSpillover(player, damageModel, sourcePart, remainingDamage)
+            return
+        }
+
+        // Standard spillover for arms and legs: goes to body
+        // Bullets: 0.8 (20% energy loss in flesh), Explosions: 1.0 (shockwave transfers fully)
+        val ratio = if (isExplosion) 1.0f else 0.8f
+        val spilloverDamage = remainingDamage * ratio
+
+        if (spilloverDamage <= 0) return
+
+        val bodyPart = damageModel.getFromEnum(EnumPlayerPart.BODY)
+        bodyPart.damage(spilloverDamage, player, true)
+        syncPart(player, damageModel, EnumPlayerPart.BODY)
+    }
+
+    /**
+     * Handles spillover from feet specifically: 80% to leg, if leg is destroyed then 40% to body.
+     */
+    private fun handleFootSpillover(
+        player: Player,
+        damageModel: AbstractPlayerDamageModel,
+        footPart: EnumPlayerPart,
+        remainingDamage: Float
+    ) {
+        val legPart = if (footPart == EnumPlayerPart.LEFT_FOOT)
+            EnumPlayerPart.LEFT_LEG
+        else
+            EnumPlayerPart.RIGHT_LEG
+
+        val leg = damageModel.getFromEnum(legPart)
+        val legSpillover = remainingDamage * 0.8f
+
+        if (leg.currentHealth > 0) {
+            val legUndelivered = leg.damage(legSpillover, player, true)
+            syncPart(player, damageModel, legPart)
+
+            if (legUndelivered > 0) {
+                applyToBody(player, damageModel, legUndelivered)
+            }
+        } else {
+            // Leg is destroyed, 40% goes to body instead (50% energy loss)
+            val bodySpillover = remainingDamage * 0.4f
+            applyToBody(player, damageModel, bodySpillover)
+        }
+    }
+
+    /**
+     * Helper to apply damage to body and sync.
+     */
+    private fun applyToBody(player: Player, damageModel: AbstractPlayerDamageModel, damage: Float) {
+        if (damage <= 0) return
+        val body = damageModel.getFromEnum(EnumPlayerPart.BODY)
+        body.damage(damage, player, true)
+        syncPart(player, damageModel, EnumPlayerPart.BODY)
+    }
+
+    /**
+     * Syncs a specific part to the client.
+     */
+    private fun syncPart(player: Player, damageModel: AbstractPlayerDamageModel, part: EnumPlayerPart) {
+        if (player is ServerPlayer) {
+            val partInstance = damageModel.getFromEnum(part)
+            FirstAid.NETWORKING.send(
+                PacketDistributor.PLAYER.with { player },
+                MessageUpdatePart(partInstance)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/TacZDamageDistribution.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/compat/firstaid/TacZDamageDistribution.kt
@@ -1,0 +1,89 @@
+package me.muksc.tacztweaks.compat.firstaid
+
+import com.mojang.serialization.Codec
+import ichttt.mods.firstaid.FirstAid
+import ichttt.mods.firstaid.FirstAidConfig
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel
+import ichttt.mods.firstaid.api.distribution.IDamageDistributionAlgorithm
+import ichttt.mods.firstaid.api.enums.EnumPlayerPart
+import ichttt.mods.firstaid.common.network.MessageUpdatePart
+import ichttt.mods.firstaid.common.util.ArmorUtils
+import ichttt.mods.firstaid.common.util.CommonUtils
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.damagesource.DamageSource
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.phys.Vec3
+import net.minecraftforge.network.PacketDistributor
+
+/**
+ * Custom damage distribution algorithm for TacZ bullets.
+ * Uses precise 3D hitbox detection instead of FirstAid's default random/height-based distribution.
+ */
+class TacZDamageDistribution(private val hitLocation: Vec3) : IDamageDistributionAlgorithm {
+
+    companion object {
+        val CODEC: Codec<TacZDamageDistribution> = Codec.unit { TacZDamageDistribution(Vec3.ZERO) }
+    }
+
+    override fun distributeDamage(
+        damage: Float,
+        player: Player,
+        source: DamageSource,
+        addStat: Boolean
+    ): Float {
+        val damageModel = CommonUtils.getDamageModel(player) ?: return damage
+        var currentDamage = damage
+
+        // Convert world hit to local coordinates
+        val localHit = CoordinateTransform.worldToLocal(hitLocation, player)
+
+        // Determine which bodypart was hit, fallback to closest part
+        val hitPart = BodypartHitbox.getHitPart(localHit) ?: BodypartHitbox.getClosestPart(localHit)
+
+        // Determine armor slot based on custom mapping
+        val armorSlot = getMappedSlot(hitPart)
+
+        // Apply armor absorption
+        currentDamage = ArmorUtils.applyArmor(player, player.getItemBySlot(armorSlot), source, currentDamage, armorSlot)
+        if (currentDamage <= 0F) return 0F
+
+        // Apply enchantment modifiers
+        currentDamage = ArmorUtils.applyEnchantmentModifiers(player, armorSlot, source, currentDamage)
+        if (currentDamage <= 0F) return 0F
+
+        // Apply damage to the specific part
+        val part = damageModel.getFromEnum(hitPart)
+
+        // FirstAid often leaves 1HP if configuration allows
+        val minHealth = if (part.canCauseDeath && FirstAidConfig.SERVER.useFriendlyRandomDistribution.get()) 1.0f else 0f
+
+        val undelivered = part.damage(currentDamage, player, addStat, minHealth)
+
+        // Sync to client
+        if (player is ServerPlayer) {
+            FirstAid.NETWORKING.send(PacketDistributor.PLAYER.with { player }, MessageUpdatePart(part))
+        }
+
+        if (undelivered > 0 && hitPart != EnumPlayerPart.BODY && hitPart != EnumPlayerPart.HEAD) {
+            // Apply spillover to body
+            SpilloverHandler.applySpillover(player, hitPart, undelivered, false)
+        }
+
+        // We return 0 as we've already handled the "excess" via spillover logic
+        return 0f
+    }
+
+    /**
+     * Maps a body part to an equipment slot for armor protection calculation,
+     * following the user's specific protection requirements.
+     */
+    private fun getMappedSlot(part: EnumPlayerPart): EquipmentSlot = when (part) {
+        EnumPlayerPart.HEAD -> EquipmentSlot.HEAD
+        EnumPlayerPart.BODY, EnumPlayerPart.LEFT_ARM, EnumPlayerPart.RIGHT_ARM -> EquipmentSlot.CHEST
+        EnumPlayerPart.LEFT_LEG, EnumPlayerPart.RIGHT_LEG -> EquipmentSlot.LEGS
+        EnumPlayerPart.LEFT_FOOT, EnumPlayerPart.RIGHT_FOOT -> EquipmentSlot.FEET
+    }
+
+    override fun codec(): Codec<out IDamageDistributionAlgorithm> = CODEC
+}

--- a/src/main/resources/tacztweaks.mixins.json
+++ b/src/main/resources/tacztweaks.mixins.json
@@ -14,6 +14,8 @@
     "accessor.InaccuracyTypeAccessor",
     "compat.firstaid.EntityKineticBulletMixin",
     "compat.firstaid.EventHandlerMixin",
+    "compat.firstaid.EntityKineticBulletHitCaptureMixin",
+    "compat.firstaid.FirstAidEventHandlerMixin",
     "compat.lrtactical.MeleeItemMixin",
     "compat.lso.CommonForgeEventsMixin",
     "compat.mts.EntityUtilMixin",


### PR DESCRIPTION
# PR: 3D Hitbox Integration for FirstAid compat

This PR implements advanced 3D hitbox detection for player entities when hit by TaCZ projectiles. Currently, damage distribution in FirstAid is often height-based or random; this change uses the actual impact coordinates to determine the targeted body part.

Improvements:
- **Prone/Crawl Support**: Impact coordinates are transformed to account for the player's rotation and pose. Hitboxes are correctly mapped even when the player is crawling (90° offset).
- **Precision Targeting**: Allows for accurate headshots and limb hits based on the bullet's 3D impact location.
- **Positional Armor**: Maps body parts to their corresponding armor slots (e.g., arms are guarded by the chestplate).
- **Damage Spillover**: Overkill damage on limbs is correctly transferred to the torso.

## Implementation Details

### Logic Components (Kotlin)
- [CoordinateTransform](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/compat/firstaid/CoordinateTransform.java#14-104): Handles world-to-local coordinate conversion, including inverse yaw rotation and crawling pose adjustments.
- [BodypartHitbox](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/compat/firstaid/BodypartHitbox.java#16-154): Defines static AABBs for player parts relative to the entity center.
- [TacZDamageDistribution](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/compat/firstaid/TacZDamageDistribution.java#25-107): Custom `IDamageDistributionAlgorithm` that uses the captured 3D hit location.
- [SpilloverHandler](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/compat/firstaid/SpilloverHandler.java#14-124): Logic for transferring limb damage to the torso.

### Mixin Hooks (Java)
- [EntityKineticBulletHitCaptureMixin](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/EntityKineticBulletHitCaptureMixin.java#16-29): Injects into [onHitEntity](file:///c:/crossfire/TaCZTweaks-main/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/EntityKineticBulletMixin.java#16-22) to store the exact `Vec3` hit location on the bullet entity via a duck interface.
- [FirstAidEventHandlerMixin](file:///c:/crossfire/TaCZ%20Tweaks%20v2.12.0%20compat/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/FirstAidEventHandlerMixin.java#25-101): Intercepts FirstAid's damage distribution event to substitute our 3D logic for TaCZ bullets.

## Technical Notes
- **Conditional Loading**: All FirstAid-specific mixins are guarded by a Mixin Plugin and only load if the mod is present.
- **Duck Interface**: [EntityKineticBullet](file:///c:/crossfire/TaCZTweaks-main/src/main/java/me/muksc/tacztweaks/mixin/compat/firstaid/EntityKineticBulletMixin.java#14-23) now implements [EntityKineticBulletExtension](file:///c:/crossfire/TacZTweaks/src/main/java/me/muksc/tacztweaks/mixininterface/features/EntityKineticBulletExtension.java#6-43) to store `tacztweaks$lastHitLocation`.
****