### PR TITLE
feat: allow bullets to destroy Sable (Create Aeronautics) sublevel blocks

### DIFF
--- a/src/main/kotlin/me/muksc/tacztweaks/feature/datapack/legacy/manager/BulletInteractionManager.kt
+++ b/src/main/kotlin/me/muksc/tacztweaks/feature/datapack/legacy/manager/BulletInteractionManager.kt
@@ -20,6 +20,10 @@ import me.muksc.tacztweaks.feature.datapack.shield.CustomShieldResult
 import me.muksc.tacztweaks.mixin.accessor.EntityKineticBulletAccessor
 import me.muksc.tacztweaks.mixininterface.feature.datapack.TaCZTweaksBullet
 import me.muksc.tacztweaks.mixininterop.*
+//? if neoforge {
+import dev.ryanhcode.sable.Sable
+import dev.ryanhcode.sable.sublevel.SubLevel
+//?}
 import net.minecraft.core.BlockPos
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerLevel
@@ -238,6 +242,20 @@ object BulletInteractionManager : BaseDataManager<BulletInteraction>("bullet_int
     ) {
         //? if fabric
         //val blockEntity by lazy { level.getBlockEntity(pos) }
+        //? if neoforge {
+        if (Config.General.Compatibility.sableCompat()) {
+            val sableSub = Sable.HELPER.getContaining(level, pos)
+            if (sableSub != null) {
+                val sableLevel = sableSub.getLevel()
+                val localPos = sableSub.logicalPose().transformPositionInverse(pos.getCenter())
+                val homePos = BlockPos.containing(localPos)
+                if (sableLevel is ServerLevel && !sableLevel.getBlockState(homePos).isAir) {
+                    sableLevel.destroyBlock(homePos, blockBreak.drop, entity)
+                    return
+                }
+            }
+        }
+        //?}
         if (entity is ServerPlayer) {
             //? if fabric {
             /*if (!PlayerBlockBreakEvents.BEFORE.invoker().beforeBlockBreak(level, entity, pos, state, blockEntity)) {


### PR DESCRIPTION
## Summary

When a bullet hits a **Create Aeronautics** (Sable) sublevel - i.e. an assembled aircraft - the block break now gets redirected to the sublevel's own world so the ship block is actually destroyed, instead of being applied to the main world at an empty position. This enables **anti-air / shooting-down-aircraft gameplay**: a small-arms round can damage or break the airframe blocks out from under a flying machine.

## Problem

Previously `BulletInteractionManager.destroyBlock` always broke the block on the bullet's level (`bullet.level()` ? main world `ServerLevel`) at the raycast hit position. Sable stores aircraft blocks in an independent **sublevel** world (`ServerSubLevel`), so a round that clip-projected onto a ship reported a sublevel-local position that, when applied to the main world, hit nothing - the bullet visually passed straight through the aircraft.

## What was changed

In `BulletInteractionManager.destroyBlock`, on the `neoforge` platform and only when the existing `sableCompat` option is enabled:

- Ask `Sable.HELPER.getContaining(level, pos)` whether the hit position belongs to a Sable sublevel.
- If it does, transform the world hit position into sublevel-local coordinates via `SubLevel.logicalPose().transformPositionInverse(...)`.
- Look up the block in the sublevel's own `ServerLevel` and, if it is not air, destroy it there (honouring the configured `drop` flag) and return immediately.

The change is gated behind the already-present `sableCompat` compatibility toggle and is currently scoped to `neoforge` (the platform where Sable ships). Existing main-world block-breaking behaviour is untouched.

## Notes / follow-ups

- This covers the *break* path (making the ship block breakable once hit). Applying the round damage/penetration to the airframe's structural integrity is a natural follow-up but out of scope here.
- Only tested on the `1.21.1-neoforge` variant.

## Testing

- Compiles against Sable `1.0.6` (compile scope) and runs with Sable `2.0.3`.
- Requires setting `sableCompat: true` in `tacztweaks.json` and a server restart for the syncable config to take effect.